### PR TITLE
Add custom user agent to API request

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -161,7 +161,13 @@ func main() {
 		log.Debug().Msg("Decoding JSON input")
 
 		var err error
-		componentsSet, err = components.NewFromURL(ctx, cfg.URL, cfg.ReadLimit, cfg.AllowUnknownJSONFields)
+		componentsSet, err = components.NewFromURL(
+			ctx,
+			cfg.URL,
+			cfg.ReadLimit,
+			cfg.AllowUnknownJSONFields,
+			cfg.UserAgent(),
+		)
 		if err != nil {
 			log.Error().Err(err).Msg("Error decoding JSON feed")
 

--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -95,7 +95,13 @@ func main() {
 		log.Debug().Msg("Decoding JSON input")
 
 		var err error
-		componentsSet, err = components.NewFromURL(ctx, cfg.URL, cfg.ReadLimit, cfg.AllowUnknownJSONFields)
+		componentsSet, err = components.NewFromURL(
+			ctx,
+			cfg.URL,
+			cfg.ReadLimit,
+			cfg.AllowUnknownJSONFields,
+			cfg.UserAgent(),
+		)
 		if err != nil {
 			log.Error().Err(err).Msg("Error decoding JSON feed")
 

--- a/internal/statuspage/components/components.go
+++ b/internal/statuspage/components/components.go
@@ -188,8 +188,9 @@ type Filter struct {
 // NewFromURL constructs a components Set by reading and decoding JSON data
 // from a specified URL using the specified number of bytes as the read limit.
 // If specified, unknown fields in the JSON file are ignored. An error is
-// returned if there are problems reading and decoding JSON data.
-func NewFromURL(ctx context.Context, apiURL string, limit int64, allowUnknownFields bool) (*Set, error) {
+// returned if there are problems reading and decoding JSON data. If provided,
+// a custom user agent is supplied in place of the default Go user agent.
+func NewFromURL(ctx context.Context, apiURL string, limit int64, allowUnknownFields bool, userAgent string) (*Set, error) {
 
 	logger.Printf("Validating URL %q before attempting to read data", apiURL)
 	parsedURL, err := url.Parse(apiURL)
@@ -216,6 +217,12 @@ func NewFromURL(ctx context.Context, apiURL string, limit int64, allowUnknownFie
 
 	// Explicitly note that we want JSON content.
 	request.Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	// If provided, override the default Go user agent ("Go-http-client/1.1")
+	// with custom value.
+	if userAgent != "" {
+		request.Header.Set("User-Agent", userAgent)
+	}
 
 	logger.Print("Submitting HTTP request")
 	response, err := c.Do(request)


### PR DESCRIPTION
Override default value of `Go-http-client/1.1` with custom user
agent value representing this project and a specific release
version.

At present, the same value is used for the components plugin
and the components CLI app.

fixes GH-4