### PR TITLE
Properly handle help flags

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -66,6 +66,11 @@ func main() {
 
 		return
 
+	case errors.Is(cfgErr, config.ErrHelpRequested):
+		cfg.Help()
+
+		return
+
 	case cfgErr != nil:
 		// We're using the standalone Err function from rs/zerolog/log as we
 		// do not have a working configuration.

--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -37,6 +37,11 @@ func main() {
 
 		return
 
+	case errors.Is(cfgErr, config.ErrHelpRequested):
+		cfg.Help()
+
+		return
+
 	case cfgErr != nil:
 		// We're using the standalone Err function from rs/zerolog/log as we
 		// do not have a working configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,7 @@ package config
 import (
 	"flag"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/atc0005/check-statuspage/internal/textutils"
@@ -34,6 +35,8 @@ var expectedInspectorComponentsFlags = []string{
 }
 
 var expectedSharedFlags = []string{
+	HelpFlagLong,
+	HelpFlagShort,
 	OmitOKComponentsFlagShort,
 	OmitOKComponentsFlagLong,
 	URLFlagShort,
@@ -85,9 +88,9 @@ func TestExpectedPluginComponentsFlags(t *testing.T) {
 		Plugin:  appTypeLabel(appType),
 	}
 
-	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	config.flagSet = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-	if err := config.handleFlagsConfig(flagSet, appType); err != nil {
+	if err := config.handleFlagsConfig(appType); err != nil {
 		t.Fatalf(
 			"ERROR: Failed to set flags configuration: %v",
 			err,
@@ -97,7 +100,7 @@ func TestExpectedPluginComponentsFlags(t *testing.T) {
 	totalExpectedFlagsCount := len(expectedSharedFlags) + len(expectedPluginComponentsFlags)
 
 	definedFlags := make([]string, 0, totalExpectedFlagsCount)
-	flagSet.VisitAll(func(f *flag.Flag) {
+	config.flagSet.VisitAll(func(f *flag.Flag) {
 		definedFlags = append(definedFlags, f.Name)
 	})
 	definedFlagsCount := len(definedFlags)
@@ -143,6 +146,145 @@ func TestExpectedPluginComponentsFlags(t *testing.T) {
 
 }
 
+// TestHelpFlag asserts that specifying help flags is both successful and
+// output contains all expected flags for the application type (e.g.,
+// components plugin vs components cli app).
+func TestHelpFlag(t *testing.T) {
+
+	// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
+
+	// Save old command-line arguments so that we can restore them later
+	oldArgs := os.Args
+
+	// Defer restoring original command-line arguments
+	defer func() { os.Args = oldArgs }()
+
+	tests := []struct {
+		name    string
+		appName string
+		appType AppType
+		flag    string
+	}{
+		{
+			name:    "Components plugin, short help flag",
+			appName: PluginComponentsAppName,
+			appType: AppType{PluginComponents: true},
+			flag:    HelpFlagShort,
+		},
+		{
+			name:    "Components plugin, long help flag",
+			appName: PluginComponentsAppName,
+			appType: AppType{PluginComponents: true},
+			flag:    HelpFlagLong,
+		},
+		{
+			name:    "Components CLI app, short help flag",
+			appName: InspectorComponentsAppName,
+			appType: AppType{InspectorComponents: true},
+			flag:    HelpFlagShort,
+		},
+		{
+			name:    "Components CLI app, long help flag",
+			appName: InspectorComponentsAppName,
+			appType: AppType{InspectorComponents: true},
+			flag:    HelpFlagLong,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Save old command-line arguments so that we can restore them later
+			// https://stackoverflow.com/questions/33723300/how-to-test-the-passing-of-arguments-in-golang
+			oldArgs := os.Args
+
+			// Defer restoring original command-line arguments
+			defer func() { os.Args = oldArgs }()
+
+			// Clear out any entries added by `go test` or leftovers from
+			// previous test cases.
+			os.Args = nil
+
+			// Note to self: Don't add/escape double-quotes here. The shell strips
+			// them away and the application never sees them.
+			flagsAndValuesInOrder := []string{
+				test.appName, test.flag,
+			}
+
+			for i, item := range flagsAndValuesInOrder {
+				if strings.TrimSpace(item) != "" {
+					os.Args = append(os.Args, item)
+				} else {
+					t.Logf("Skipping item %d due to empty value", i)
+				}
+			}
+
+			t.Log("INFO: Old os.Args before rewriting:\n", oldArgs)
+			t.Log("INFO: New os.Args before init config:\n", os.Args)
+
+			var config Config
+			config.App = AppInfo{
+				Name:    myAppName,
+				Version: version,
+				URL:     myAppURL,
+				Plugin:  appTypeLabel(test.appType),
+			}
+
+			config.flagSet = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			if err := config.handleFlagsConfig(test.appType); err != nil {
+				t.Fatalf(
+					"ERROR: Failed to set flags configuration: %v",
+					err,
+				)
+			}
+
+			helpOutput := config.Help()
+
+			// t.Logf("helpOutput: %s", helpOutput)
+
+			// Quick fail: look for known failure text in output.
+			if strings.Contains(helpOutput, ErrConfigNotInitialized.Error()) {
+				t.Fatalf(
+					"ERROR: Help text indicates uninitialized configuration: %s",
+					ErrConfigNotInitialized,
+				)
+			}
+
+			// combine the shared and dedicated flag lists
+			expectedFlags := make([]string, 0, len(expectedSharedFlags)+len(expectedPluginComponentsFlags))
+			switch {
+			case test.appType.InspectorComponents:
+				expectedFlags = append(expectedFlags, expectedSharedFlags...)
+				expectedFlags = append(expectedFlags, expectedInspectorComponentsFlags...)
+			case test.appType.PluginComponents:
+				expectedFlags = append(expectedFlags, expectedSharedFlags...)
+				expectedFlags = append(expectedFlags, expectedPluginComponentsFlags...)
+
+			}
+
+			// Ensure that we get useful help output by confirming that each
+			// defined flag is represented in the generated output.
+			for _, expectedFlag := range expectedFlags {
+				switch {
+				case !strings.Contains(helpOutput, expectedFlag):
+					t.Fatalf(
+						"ERROR: Help text is missing usage information for flag %q",
+						expectedFlag,
+					)
+
+				default:
+					t.Logf(
+						"OK: Help text usage information for flag %q found",
+						expectedFlag,
+					)
+				}
+			}
+		})
+	}
+
+}
+
 // TestExpectedInspectorComponentsFlags tests defined config flags for the
 // components inspector app against a list of expected flags for the CLI app.
 // This is done to help prevent documentation from getting out of date with
@@ -174,9 +316,9 @@ func TestExpectedInspectorComponentsFlags(t *testing.T) {
 		Plugin:  appTypeLabel(appType),
 	}
 
-	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	config.flagSet = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-	if err := config.handleFlagsConfig(flagSet, appType); err != nil {
+	if err := config.handleFlagsConfig(appType); err != nil {
 		t.Fatalf(
 			"ERROR: Failed to set flags configuration: %v",
 			err,
@@ -186,7 +328,7 @@ func TestExpectedInspectorComponentsFlags(t *testing.T) {
 	totalExpectedFlagsCount := len(expectedSharedFlags) + len(expectedInspectorComponentsFlags)
 
 	definedFlags := make([]string, 0, totalExpectedFlagsCount)
-	flagSet.VisitAll(func(f *flag.Flag) {
+	config.flagSet.VisitAll(func(f *flag.Flag) {
 		definedFlags = append(definedFlags, f.Name)
 	})
 	definedFlagsCount := len(definedFlags)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -12,6 +12,8 @@ const myAppURL string = "https://github.com/atc0005/" + myAppName
 
 // Flag names. Exported so that they can be referenced from tests.
 const (
+	HelpFlagLong                    string = "help"
+	HelpFlagShort                   string = "h"
 	VersionFlagLong                 string = "version"
 	VersionFlagShort                string = "v"
 	BrandingFlag                    string = "branding"
@@ -41,6 +43,7 @@ const (
 
 // Common or shared flag help text
 const (
+	helpFlagHelp                   string = "Emit this help text"
 	versionFlagHelp                string = "Whether to display application version and then immediately exit application."
 	logLevelFlagHelp               string = "Sets log level to one of disabled, panic, fatal, error, warn, info, debug or trace."
 	urlFlagHelp                    string = "The fully-qualified URL of a Statuspage API/JSON feed (e.g., https://www.githubstatus.com/api/v2/components.json)."
@@ -70,6 +73,7 @@ const (
 	defaultFilename               string = ""
 	defaultLogLevel               string = "info"
 	defaultComponentGroup         string = ""
+	defaultHelp                   bool   = false
 	defaultBranding               bool   = false
 	defaultOmitOKComponents       bool   = false
 	defaultEvalAllComponents      bool   = false

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -8,7 +8,7 @@
 package config
 
 import (
-	"flag"
+	"fmt"
 	"os"
 )
 
@@ -17,61 +17,75 @@ import (
 // application type as set by each cmd. Based on the application's specified
 // type, a smaller subset of flags specific to each type are exposed along
 // with a set common to all application types.
-func (c *Config) handleFlagsConfig(flagSet *flag.FlagSet, appType AppType) error {
+func (c *Config) handleFlagsConfig(appType AppType) error {
+
+	if c == nil {
+		return fmt.Errorf(
+			"nil configuration, cannot process flags: %w",
+			ErrConfigNotInitialized,
+		)
+	}
 
 	// Flags specific to one plugin type or the other
 	switch {
 	case appType.PluginComponents:
 
-		flagSet.BoolVar(&c.EmitBranding, BrandingFlag, defaultBranding, brandingFlagHelp)
+		c.flagSet.BoolVar(&c.EmitBranding, BrandingFlag, defaultBranding, brandingFlagHelp)
 
-		flagSet.Var(&c.componentsList, ComponentsListFlagShort, componentsListFlagHelp+" (shorthand)")
-		flagSet.Var(&c.componentsList, ComponentsListFlagLong, componentsListFlagHelp)
+		c.flagSet.Var(&c.componentsList, ComponentsListFlagShort, componentsListFlagHelp+" (shorthand)")
+		c.flagSet.Var(&c.componentsList, ComponentsListFlagLong, componentsListFlagHelp)
 
-		flagSet.StringVar(&c.componentGroup, ComponentGroupFlagShort, defaultComponentGroup, componentGroupFlagHelp+" (shorthand)")
-		flagSet.StringVar(&c.componentGroup, ComponentGroupFlagLong, defaultComponentGroup, componentGroupFlagHelp)
+		c.flagSet.StringVar(&c.componentGroup, ComponentGroupFlagShort, defaultComponentGroup, componentGroupFlagHelp+" (shorthand)")
+		c.flagSet.StringVar(&c.componentGroup, ComponentGroupFlagLong, defaultComponentGroup, componentGroupFlagHelp)
 
-		flagSet.BoolVar(&c.EvalAllComponents, EvalAllComponentsFlagShort, defaultEvalAllComponents, evalAllComponentsFlagHelp+" (shorthand)")
-		flagSet.BoolVar(&c.EvalAllComponents, EvalAllComponentsFlagLong, defaultEvalAllComponents, evalAllComponentsFlagHelp)
+		c.flagSet.BoolVar(&c.EvalAllComponents, EvalAllComponentsFlagShort, defaultEvalAllComponents, evalAllComponentsFlagHelp+" (shorthand)")
+		c.flagSet.BoolVar(&c.EvalAllComponents, EvalAllComponentsFlagLong, defaultEvalAllComponents, evalAllComponentsFlagHelp)
 
 	case appType.InspectorComponents:
 
-		flagSet.StringVar(&c.InspectorOutputFormat, InspectorOutputFormatFlagShort, defaultInspectorOutputFormat, inspectorOutputFormatFlagHelp+" (shorthand)")
-		flagSet.StringVar(&c.InspectorOutputFormat, InspectorOutputFormatFlagLong, defaultInspectorOutputFormat, inspectorOutputFormatFlagHelp)
+		c.flagSet.StringVar(&c.InspectorOutputFormat, InspectorOutputFormatFlagShort, defaultInspectorOutputFormat, inspectorOutputFormatFlagHelp+" (shorthand)")
+		c.flagSet.StringVar(&c.InspectorOutputFormat, InspectorOutputFormatFlagLong, defaultInspectorOutputFormat, inspectorOutputFormatFlagHelp)
 
 	}
 
 	// Shared flags for all application types
 
-	flagSet.BoolVar(&c.OmitOKComponents, OmitOKComponentsFlagShort, defaultOmitOKComponents, omitOKComponentsFlagHelp+" (shorthand)")
-	flagSet.BoolVar(&c.OmitOKComponents, OmitOKComponentsFlagLong, defaultOmitOKComponents, omitOKComponentsFlagHelp)
+	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagLong, defaultHelp, helpFlagHelp)
 
-	flagSet.StringVar(&c.URL, URLFlagShort, defaultURL, urlFlagHelp+" (shorthand)")
-	flagSet.StringVar(&c.URL, URLFlagLong, defaultURL, urlFlagHelp)
+	c.flagSet.BoolVar(&c.OmitOKComponents, OmitOKComponentsFlagShort, defaultOmitOKComponents, omitOKComponentsFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.OmitOKComponents, OmitOKComponentsFlagLong, defaultOmitOKComponents, omitOKComponentsFlagHelp)
 
-	flagSet.StringVar(&c.Filename, FilenameFlagShort, defaultFilename, filenameFlagHelp+" (shorthand)")
-	flagSet.StringVar(&c.Filename, FilenameFlagLong, defaultFilename, filenameFlagHelp)
+	c.flagSet.StringVar(&c.URL, URLFlagShort, defaultURL, urlFlagHelp+" (shorthand)")
+	c.flagSet.StringVar(&c.URL, URLFlagLong, defaultURL, urlFlagHelp)
 
-	flagSet.BoolVar(&c.AllowUnknownJSONFields, AllowUnknownJSONFieldsFlagShort, defaultAllowUnknownJSONFields, allowUnknownJSONFieldsFlagHelp+" (shorthand)")
-	flagSet.BoolVar(&c.AllowUnknownJSONFields, AllowUnknownJSONFieldsFlagLong, defaultAllowUnknownJSONFields, allowUnknownJSONFieldsFlagHelp)
+	c.flagSet.StringVar(&c.Filename, FilenameFlagShort, defaultFilename, filenameFlagHelp+" (shorthand)")
+	c.flagSet.StringVar(&c.Filename, FilenameFlagLong, defaultFilename, filenameFlagHelp)
 
-	flagSet.Int64Var(&c.ReadLimit, ReadLimitFlagShort, defaultReadLimit, readLimitFlagHelp+" (shorthand)")
-	flagSet.Int64Var(&c.ReadLimit, ReadLimitFlagLong, defaultReadLimit, readLimitFlagHelp)
+	c.flagSet.BoolVar(&c.AllowUnknownJSONFields, AllowUnknownJSONFieldsFlagShort, defaultAllowUnknownJSONFields, allowUnknownJSONFieldsFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.AllowUnknownJSONFields, AllowUnknownJSONFieldsFlagLong, defaultAllowUnknownJSONFields, allowUnknownJSONFieldsFlagHelp)
 
-	flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultRuntimeTimeout, timeoutRuntimeFlagHelp+" (shorthand)")
-	flagSet.IntVar(&c.timeout, TimeoutFlagLong, defaultRuntimeTimeout, timeoutRuntimeFlagHelp)
+	c.flagSet.Int64Var(&c.ReadLimit, ReadLimitFlagShort, defaultReadLimit, readLimitFlagHelp+" (shorthand)")
+	c.flagSet.Int64Var(&c.ReadLimit, ReadLimitFlagLong, defaultReadLimit, readLimitFlagHelp)
 
-	flagSet.StringVar(&c.LoggingLevel, LogLevelFlagShort, defaultLogLevel, logLevelFlagHelp+" (shorthand)")
-	flagSet.StringVar(&c.LoggingLevel, LogLevelFlagLong, defaultLogLevel, logLevelFlagHelp)
+	c.flagSet.IntVar(&c.timeout, TimeoutFlagShort, defaultRuntimeTimeout, timeoutRuntimeFlagHelp+" (shorthand)")
+	c.flagSet.IntVar(&c.timeout, TimeoutFlagLong, defaultRuntimeTimeout, timeoutRuntimeFlagHelp)
 
-	flagSet.BoolVar(&c.ShowVersion, VersionFlagShort, defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
-	flagSet.BoolVar(&c.ShowVersion, VersionFlagLong, defaultDisplayVersionAndExit, versionFlagHelp)
+	c.flagSet.StringVar(&c.LoggingLevel, LogLevelFlagShort, defaultLogLevel, logLevelFlagHelp+" (shorthand)")
+	c.flagSet.StringVar(&c.LoggingLevel, LogLevelFlagLong, defaultLogLevel, logLevelFlagHelp)
 
-	// Allow our function to override the default Help output
-	flagSet.Usage = Usage(flagSet)
+	c.flagSet.BoolVar(&c.ShowVersion, VersionFlagShort, defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.ShowVersion, VersionFlagLong, defaultDisplayVersionAndExit, versionFlagHelp)
+
+	// Allow our function to override the default Help output.
+	//
+	// Override default of stderr as destination for help output. This allows
+	// Nagios XI and similar monitoring systems to call plugins with the
+	// `--help` flag and have it display within the Admin web UI.
+	c.flagSet.Usage = Usage(c.flagSet, os.Stdout)
 
 	// parse flag definitions from the argument list
-	if err := flagSet.Parse(os.Args[1:]); err != nil {
+	if err := c.flagSet.Parse(os.Args[1:]); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Overview

Due to an earlier change intended to better support testing, the
flag.ErrHelp error value was not explicitly handled and resulted in a
configuration initialization error scenario.

This caused both binaries currently provided by the project to
essentially go up in flames when the user requested usage information.

This commit makes multiple changes, most to correct the current issue,
but also provide some additional coverage to help prevent a similar
issue in the future.

## Changes

- Add new explicit `-h` and `--help` flags
- Add explicit `config.ErrHelpRequested` error value to mimic the
  `flag.ErrHelp` error value
- Add explicit `config.ErrConfigNotInitialized` error value for future
  use in tests and from package consumers
- Modify `config.New()` to return the `config.Config` value when the
  user requests either the application version or help/usage
  information vs returning `nil`
  - the `Config` value is properly initialized at this point, so
    returning it so that it can be used for the very specific
    `config.ErrHelpRequested` and `config.ErrVersionRequested` error
    values
- Add test cases to assert that both `-h` and `--help` are recognized
  as flags
- Fail early when encountering a nil configuration
- Move custom FlagSet into an unexpected `flagSet` `Config` field and
  update existing tests and methods to account for this change
- Update `config.Usage()` function to accept an `io.Writer` for the
  desired output destination, but allow overriding this value later if
  desired
- Add `Config.Help()` method
  - overrides the output destination for usage and error information
    set previously during config initialization
  - emits usage information as a string value for use in tests and as
    expected output for user review

fixes GH-23