### PR TITLE
Restore Help output

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -67,7 +67,7 @@ func main() {
 		return
 
 	case errors.Is(cfgErr, config.ErrHelpRequested):
-		cfg.Help()
+		fmt.Println(cfg.Help())
 
 		return
 

--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -38,7 +38,7 @@ func main() {
 		return
 
 	case errors.Is(cfgErr, config.ErrHelpRequested):
-		cfg.Help()
+		fmt.Println(cfg.Help())
 
 		return
 


### PR DESCRIPTION
An earlier revision to resolve GH-23 emitted output directly to stdout. When I updated the Help() method (GH-25) to emit a string value to the caller, I failed to update the CLI app and plugin to account for that change.

fixes GH-23 (redux)