### PR TITLE
Rework `reports.ComponentsReport()`, `reports.ComponentsTable()` funcs

### DIFF
--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -131,7 +131,18 @@ func main() {
 		fmt.Print(reports.ComponentsOverview(componentsSet, cfg.OmitOKComponents))
 
 	case config.InspectorOutputFormatTable:
-		fmt.Print(reports.ComponentsTable(componentsSet, cfg.OmitOKComponents))
+		// Enable all columns in filter
+		columnFilter := reports.ComponentsTableColumnFilter{
+			GroupName:     true,
+			GroupID:       true,
+			ComponentName: true,
+			ComponentID:   true,
+			Evaluated:     true,
+			Status:        true,
+		}
+
+		// Generate table, providing our "use everything" filter.
+		fmt.Print(reports.ComponentsTable(componentsSet, cfg.OmitOKComponents, &columnFilter))
 
 	case config.InspectorOutputFormatVerbose:
 		fmt.Print(reports.ComponentsVerbose(componentsSet, cfg.OmitOKComponents))


### PR DESCRIPTION
- `reports.ComponentsReport()` func
  - clarify output limit logic
  - apply column filter to drop optional fields
    - `GroupID`
    - `ComponentID`
    - `Evaluated`

- `reports.ComponentsTable()` func
  - update to use new column filter, default to
    original display if not explicitly specified
  - rework internal logic to use `componentsTable`
    type, related types & methods to control column
    display based on given filter

- `cmd/lscs` binary
  - explicitly provide a `ComponentsTableColumnFilter`
    for use with the `table` format

fixes GH-33