### PR TITLE
Update Nagios command defs to omit OK components

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,8 +847,10 @@ Summary:
 
 #### Command definition
 
-The snippet below represents a command definition file where three commands
-are defined for
+The command definition file below defines three commands. Each command
+explicitly excludes "OK" components in order to keep the output manageable.
+Remove the `omit-ok` flag if you wish to use the built-in components output
+limit to control the number of components emitted.
 
 ```shell
 # /etc/nagios-plugins/config/statuspage-components.cfg
@@ -856,7 +858,7 @@ are defined for
 # Evaluate all components for a specified component group.
 define command{
     command_name    check_statuspage_components_group
-    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --group '$ARG2$' --log-level info
+    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --group '$ARG2$' --omit-ok --log-level info
     }
 
 # Evaluate one or more components for a (single) specified component group.
@@ -865,7 +867,7 @@ define command{
 # a mix of component names and/or ID values.
 define command{
     command_name    check_statuspage_components_group_and_select_subcomponents
-    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --group '$ARG2$' --component '$ARG3$' --log-level info
+    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --group '$ARG2$' --component '$ARG3$' --omit-ok --log-level info
     }
 
 # Evaluate one or more components regardless of component group.
@@ -874,7 +876,7 @@ define command{
 # a mix of component names and/or ID values.
 define command{
     command_name    check_statuspage_components_list
-    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --component '$ARG2$' --log-level info
+    command_line    $USER1$/check_statuspage_components --url '$ARG1$' --component '$ARG2$' --omit-ok --log-level info
     }
 ```
 


### PR DESCRIPTION
- omit OK components to help keep the output manageable
- add note explaining why this is used, note expected
  behavior if it is not specified

fixes GH-30