### PR TITLE
Restore use of spaces instead of tabs in report

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -104,9 +104,13 @@ func newComponentsTable(columnsList ComponentsTableColumnFilter) *componentsTabl
 
 	table.filter = columnsList
 
-	// w := tabwriter.NewWriter(&table.report, 4, 4, 4, ' ', 0)
+	w := tabwriter.NewWriter(&table.report, 4, 4, 4, ' ', 0)
 	// w := tabwriter.NewWriter(&table.report, 4, 4, 4, ' ', tabwriter.Debug|tabwriter.DiscardEmptyColumns)
-	w := tabwriter.NewWriter(&table.report, 0, 8, 2, '\t', 0)
+
+	// See GH-44 regarding issues with lack of spacing between columns in
+	// email notifications (when using tabs).
+	//
+	// w := tabwriter.NewWriter(&table.report, 0, 8, 2, '\t', 0)
 	table.tabWriter = w
 
 	return &table


### PR DESCRIPTION
Recent testing has shown that using tabs results in the columns
running together without visible spacing in email notifications.
Fallback to using spaces and just keeping the minimum number of
displayed columns in an effort to make the content readable at
a glance.

fixes GH-44