### PR TITLE
Fix incomplete summary when failing to parse JSON

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -180,7 +180,7 @@ func main() {
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
 				"%s: Failed to decode JSON feed from %q",
 				nagios.StateCRITICALLabel,
-				cfg.Filename,
+				cfg.URL,
 			)
 			nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 


### PR DESCRIPTION
Add missing source of feed to one-line summary.

fixes GH-60