### PR TITLE
Refactor handling of prep tasks and errors

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -140,30 +140,34 @@ func main() {
 
 		feedSource = cfg.Filename
 
-		log.Debug().Msg("Decoding JSON input")
+		log.Debug().Msg("Processing JSON file")
 
 		var err error
 		componentsSet, err = components.NewFromFile(cfg.Filename, cfg.ReadLimit, cfg.AllowUnknownJSONFields)
 		if err != nil {
-			log.Error().Err(err).Msg("Error decoding JSON feed")
+			log.Error().Err(err).Msg("Error occurred processing input file")
 
 			nagiosExitState.LastError = err
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
-				"%s: Failed to decode JSON feed from %q",
+				"%s: Failed to process JSON feed from file",
 				nagios.StateCRITICALLabel,
-				cfg.Filename,
 			)
 			nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
+			var prepErr *components.PrepError
+			if errors.As(err, &prepErr) {
+				nagiosExitState.ServiceOutput += ": " + prepErr.Message
+			}
+
 			return
 		}
-		log.Debug().Msg("Successfully decoded JSON input")
+		log.Debug().Msg("Successfully processed JSON file")
 
 	case cfg.URL != "":
 
 		feedSource = cfg.URL
 
-		log.Debug().Msg("Decoding JSON input")
+		log.Debug().Msg("Processing JSON feed")
 
 		var err error
 		componentsSet, err = components.NewFromURL(
@@ -174,19 +178,23 @@ func main() {
 			cfg.UserAgent(),
 		)
 		if err != nil {
-			log.Error().Err(err).Msg("Error decoding JSON feed")
+			log.Error().Err(err).Msg("Error processing JSON feed")
 
 			nagiosExitState.LastError = err
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
-				"%s: Failed to decode JSON feed from %q",
+				"%s: Failed to process JSON feed from URL",
 				nagios.StateCRITICALLabel,
-				cfg.URL,
 			)
 			nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
+			var prepErr *components.PrepError
+			if errors.As(err, &prepErr) {
+				nagiosExitState.ServiceOutput += ": " + prepErr.Message
+			}
+
 			return
 		}
-		log.Debug().Msg("Successfully decoded JSON input")
+		log.Debug().Msg("Successfully processed JSON feed")
 
 	}
 


### PR DESCRIPTION
## OVERVIEW

- tweak logging messages to indicate "processing" status instead of
  "decoding" (since more than just decoding was taking place)
- create custom `PrepError` type to handle errors encountered by
  specific prep tasks responsible for initial feed processing
  - implement `Error()`, `Is()` and `Unwrap()`
- update calling/client code to check if error is `PrepError` type
  (which it should be now) and expose the specific message field value
  which explains when the error occurred
  - logging
  - `ServiceOuptut` ("one line" output)
- refactor prep related code into helper functions
  - simplify `NewFromURL()` func
  - use `PrepError` type to gather additional details when errors are
    encountered

## REFERENCES

- fixes GH-89
- refs https://pragprog.com/titles/rggo/powerful-command-line-applications-in-go/
- refs https://go.dev/blog/error-handling-and-go
- refs https://go.dev/blog/go1.13-errors
- refs https://gabrieltanner.org/blog/golang-error-handling-definitive-guide