### PR TITLE
Apply Go 1.19 specific doc comments linting fixes

### DIFF
--- a/cmd/check_statuspage_components/doc.go
+++ b/cmd/check_statuspage_components/doc.go
@@ -1,24 +1,22 @@
 /*
-
 Nagios plugin used to monitor monitor one, many or all components from a
 status page powered by Atlassian Statuspage.
 
-PURPOSE
+# PURPOSE
 
 The output for this plugin is designed to provide the one-line summary needed
 by Nagios for quick identification of a problem while providing longer, more
 detailed information for use in email and Teams notifications
 (https://github.com/atc0005/send2teams).
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/check-statuspage) for the
 latest code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/cmd/lscs/doc.go
+++ b/cmd/lscs/doc.go
@@ -1,24 +1,22 @@
 /*
-
 A CLI app to list components from a status page powered by Atlassian
 Statuspage. Multiple output formats are supported.
 
-PURPOSE
+# PURPOSE
 
 The output for this plugin is designed to provide the one-line summary needed
 by Nagios for quick identification of a problem while providing longer, more
 detailed information for use in email and Teams notifications
 (https://github.com/atc0005/send2teams).
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/check-statuspage) for the
 latest code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/doc.go
+++ b/doc.go
@@ -1,30 +1,27 @@
 /*
-
 Go-based tooling to interact with status page APIs hosted by Atlassian
 Statuspage; NOT affiliated with or endorsed by Atlassian.
 
-PROJECT HOME
+# PROJECT HOME
 
-See our GitHub repo (https://github.com/atc0005/check-statuspage) for the latest
-code, to file an issue or submit improvements for review and potential
+See our GitHub repo (https://github.com/atc0005/check-statuspage) for the
+latest code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 Monitor availability of specific services using APIs provided by an Atlassian
 Statuspage.
 
-FEATURES
+# FEATURES
 
 Tooling for monitoring Status pages powered by Atlassian Statuspage.
 
-• a CLI app to list components in multiple output formats
+  - a CLI app to list components in multiple output formats
+  - a Nagios plugin to monitor one, many or all components
 
-• a Nagios plugin to monitor one, many or all components
-
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main


### PR DESCRIPTION
These changes are effectively a NOOP for earlier Go versions, but improve the formatting of rendered documentation.