### PR TITLE
Minor CI tool version output tweaks

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -45,4 +45,5 @@ jobs:
         # potential linting issues in bundled documentation to fail linting CI
         # runs for *our* documentation
         run: |
+          echo "markdownlint version: $(markdownlint --version)"
           markdownlint '**/*.md' --ignore node_modules --ignore vendor

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ lintinstall:
 
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
-	@echo "Installing latest staticcheck version ..."
+	@echo "Installing latest stable staticcheck version via go install command ..."
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	staticcheck --version
 


### PR DESCRIPTION
- emit markdownlint version at runtime in addition to
  after installing the tool
- tweak emitted pre-install text for staticcheck tool