### PR TITLE
Remove `Push Validation` workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Statuspage; NOT affiliated with or endorsed by Atlassian.
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/atc0005/check-statuspage)](https://github.com/atc0005/check-statuspage)
 [![Lint and Build](https://github.com/atc0005/check-statuspage/actions/workflows/lint-and-build.yml/badge.svg)](https://github.com/atc0005/check-statuspage/actions/workflows/lint-and-build.yml)
 [![Project Analysis](https://github.com/atc0005/check-statuspage/actions/workflows/project-analysis.yml/badge.svg)](https://github.com/atc0005/check-statuspage/actions/workflows/project-analysis.yml)
-[![Push Validation](https://github.com/atc0005/check-statuspage/actions/workflows/push-validation.yml/badge.svg)](https://github.com/atc0005/check-statuspage/actions/workflows/push-validation.yml)
 
 <!-- omit in toc -->
 ## Table of Contents


### PR DESCRIPTION
This workflow was removed recently, but the "status badge" was unintentionally left behind in the README file.

refs atc0005/shared-project-resources#63
refs atc0005/go-ci#847