### PR TITLE
Use UNKNOWN state for perfdata add failure

### DIFF
--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -313,6 +313,23 @@ func main() {
 		Int("remaining_problem_components", numRemainingProblemComponents).
 		Logger()
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	switch {
 	case !componentsSet.IsOKState(false):
 
@@ -353,12 +370,6 @@ func main() {
 			cfg.OmitSummaryResults,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		return
 
 	default:
@@ -382,12 +393,6 @@ func main() {
 			cfg.OmitOKComponents,
 			cfg.OmitSummaryResults,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		return
 


### PR DESCRIPTION
- abort with UNKNOWN state when failing to add/gather generated performance data
- remove duplicate perfdata add step
  - both the problem & OK state switch case blocks attempted to add perfdata metrics. Instead of updating the second to use an UNKNOWN exit state we just move the step outside of the switch statement so the step is performed just once

refs GH-196