### PR TITLE
Enable library logging for global trace level also

### DIFF
--- a/cmd/check_statuspage_components/logging.go
+++ b/cmd/check_statuspage_components/logging.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-statuspage/internal/reports"
+	"github.com/atc0005/check-statuspage/internal/statuspage"
+	"github.com/atc0005/check-statuspage/internal/statuspage/components"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		statuspage.EnableLogging()
+		components.EnableLogging()
+		reports.EnableLogging()
+
+	default:
+
+		statuspage.DisableLogging()
+		components.DisableLogging()
+		reports.DisableLogging()
+	}
+}

--- a/cmd/check_statuspage_components/main.go
+++ b/cmd/check_statuspage_components/main.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/atc0005/check-statuspage/internal/config"
 	"github.com/atc0005/check-statuspage/internal/reports"
-	"github.com/atc0005/check-statuspage/internal/statuspage"
 	"github.com/atc0005/check-statuspage/internal/statuspage/components"
 
 	"github.com/rs/zerolog"
@@ -67,19 +66,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled
-	// app-wide. Otherwise, explicitly disable library logging output.
-	switch {
-	case cfg.LoggingLevel == config.LogLevelDebug:
-		statuspage.EnableLogging()
-		components.EnableLogging()
-		reports.EnableLogging()
-
-	default:
-		statuspage.DisableLogging()
-		components.DisableLogging()
-		reports.DisableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/lscs/logging.go
+++ b/cmd/lscs/logging.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-statuspage/internal/reports"
+	"github.com/atc0005/check-statuspage/internal/statuspage"
+	"github.com/atc0005/check-statuspage/internal/statuspage/components"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		statuspage.EnableLogging()
+		components.EnableLogging()
+		reports.EnableLogging()
+
+	default:
+
+		statuspage.DisableLogging()
+		components.DisableLogging()
+		reports.DisableLogging()
+	}
+}

--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/atc0005/check-statuspage/internal/config"
 	"github.com/atc0005/check-statuspage/internal/reports"
-	"github.com/atc0005/check-statuspage/internal/statuspage"
 	"github.com/atc0005/check-statuspage/internal/statuspage/components"
 
 	zlog "github.com/rs/zerolog/log"
@@ -52,15 +51,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled
-	// app-wide. Otherwise, explicitly disable library logging output.
-	switch {
-	case cfg.LoggingLevel == config.LogLevelDebug:
-		statuspage.EnableLogging()
-
-	default:
-		statuspage.DisableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for
 	// runtime/execution.


### PR DESCRIPTION
Previously, library logging was enabled whenever debug logging was specified by the user. We now enable library logging when either debug or the trace logging level is specified by the user.