### PR TITLE
Update project to Go 1.21 series

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,8 +111,8 @@ updates:
     ignore:
       - dependency-name: "golang"
         versions:
-          - ">= 1.21"
-          - "< 1.20"
+          - ">= 1.22"
+          - "< 1.21"
 
   - package-ecosystem: docker
     directory: "/dependabot/docker/go"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.20.13
+FROM golang:1.21.6


### PR DESCRIPTION
- update Dependabot configuration for Dockerfile to ignore Go releases
  outside of the Go 1.21 release series
- update "Canary" Dockerfile to reflect one release back from latest
  release in Go 1.21 series
  - confirm that Dependabot configuration changes are working as
    intended

NOTE: We intentionally do *not* update the Go module version; bumping
the Go module version would indicate that this project *requires* a
newer Go version for functionality provided by that version and that
is not yet the case.

Refs:

- atc0005/todo#71