### PR TITLE
Remove leading indentation from components table

### DIFF
--- a/cmd/lscs/main.go
+++ b/cmd/lscs/main.go
@@ -126,7 +126,7 @@ func main() {
 		fmt.Print(reports.ComponentsOverview(componentsSet, cfg.OmitOKComponents, true))
 
 	case config.InspectorOutputFormatTable:
-		// Enable all columns in filter
+		// Enable all columns in filter by default
 		columnFilter := reports.ComponentsTableColumnFilter{
 			GroupName:     true,
 			GroupID:       true,
@@ -134,6 +134,12 @@ func main() {
 			ComponentID:   true,
 			Evaluated:     true,
 			Status:        true,
+		}
+
+		// Disable Group fields if there are no component groups to display.
+		if componentsSet.NumGroups() == 0 {
+			columnFilter.GroupID = false
+			columnFilter.GroupName = false
 		}
 
 		// Generate table, providing our "use everything" filter.

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -1159,6 +1159,12 @@ func ComponentsReport(
 		Status:        true,
 	}
 
+	// Disable Group fields if there are no component groups to display.
+	if componentsSet.NumGroups() == 0 {
+		columnFilter.GroupID = false
+		columnFilter.GroupName = false
+	}
+
 	fullTableOutputComponentsLimit := 50
 	switch {
 


### PR DESCRIPTION
Add conditional logic to skip emitting empty `GroupName` and `GroupID` columns if no component groups are listed by the given Statuspage components endpoint.

By omitting this empty column the unintentional leading indentation is removed for Statuspage pages which do not use component groups.

refs GH-410