### PR TITLE
Restore components table spacing

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -104,7 +104,7 @@ func newComponentsTable(columnsList ComponentsTableColumnFilter) *componentsTabl
 
 	table.filter = columnsList
 
-	w := tabwriter.NewWriter(&table.report, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(&table.report, 4, 4, 3, ' ', 0)
 	// w := tabwriter.NewWriter(&table.report, 4, 4, 4, ' ', tabwriter.Debug|tabwriter.DiscardEmptyColumns)
 
 	// See GH-44 regarding issues with lack of spacing between columns in


### PR DESCRIPTION
Revert most of 852954b3e3ece3ea3c687400d135f96bb61bc3f3 now that the reason for erroneous indentation has been identified/resolved.