### PR TITLE
Reduce spacing below components report header

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -301,7 +301,7 @@ func ComponentsVerbose(componentsSet *components.Set, omitOKComponents bool, ver
 
 		componentsReportHeader(&report, componentsSet)
 
-		fmt.Fprint(&report, nagios.CheckOutputEOL, nagios.CheckOutputEOL)
+		fmt.Fprint(&report, nagios.CheckOutputEOL)
 	}
 
 	if omitOKComponents {
@@ -662,7 +662,7 @@ func ComponentsTable(
 
 		componentsReportHeader(&componentsTable.report, componentsSet)
 
-		fmt.Fprint(&componentsTable.report, nagios.CheckOutputEOL, nagios.CheckOutputEOL)
+		fmt.Fprint(&componentsTable.report, nagios.CheckOutputEOL)
 	}
 
 	if omitOKComponents {


### PR DESCRIPTION
Revert some of the spacing changes from commit
428ed4752ffe7b1aad747ea1ddcf2f7c3e146aa3 for Table and Verbose output formats.