### PR TITLE
Fix localtime listing in report summary

### DIFF
--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -961,7 +961,7 @@ func componentsStatusSummary(
 		w,
 		"* Last Updated (%s): %s%s",
 		"Local",
-		componentsSet.Page.UpdatedAt.Format(time.DateTime+" PM"),
+		componentsSet.Page.UpdatedAt.Local().Format(time.DateTime+" PM"),
 		nagios.CheckOutputEOL,
 	)
 


### PR DESCRIPTION
Use `Time.Local` method as intended to explicitly set the Last Updated value to local time for display purposes.

refs GH-405